### PR TITLE
Reload templates in dev

### DIFF
--- a/lib/cell/development.rb
+++ b/lib/cell/development.rb
@@ -1,0 +1,11 @@
+module Cell
+  module Development
+    def self.included(base)
+      base.instance_eval do
+        def templates
+          Templates.new
+        end
+      end
+    end
+  end
+end

--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -45,6 +45,13 @@ else
         end
       end
 
+      initializer('cells.development') do |app|
+        if Rails.env == "development"
+          require "cell/development"
+          ViewModel.send(:include, Development)
+        end
+      end
+ 
       rake_tasks do
         load 'tasks/cells.rake'
       end


### PR DESCRIPTION
Automatically reloads cells templates in dev - no need for the pesky comment insert/remove dance any more! Speedy too!

I cherry-picked this out of the upstream patch:
https://github.com/apotonick/cells/commit/96670ea8bb441004f111f60541c434626ea27ba1

![](http://i.imgur.com/UtpDHRN.gif)
